### PR TITLE
refactor: Remove --unshallow from validation script

### DIFF
--- a/.github/scripts/validate_index.py
+++ b/.github/scripts/validate_index.py
@@ -11,7 +11,7 @@ def run(cmd):
 
 def check_branch_up_to_date():
     try:
-        run("git fetch --prune --unshallow origin main || git fetch origin main")
+        run("git fetch --prune origin main || git fetch origin main")
         base = run("git merge-base HEAD origin/main")
         main = run("git rev-parse origin/main")
         if base != main:


### PR DESCRIPTION
Removes the --unshallow flag from the git fetch command in the validation script. This is not needed as the checkout action uses fetch-depth: 0.