### PR TITLE
Fix: Resolve workflow validation error

### DIFF
--- a/.github/workflows/auto-pr-validate.yml
+++ b/.github/workflows/auto-pr-validate.yml
@@ -29,8 +29,9 @@ jobs:
           PR_EXISTS=$(gh pr view "${{ github.ref_name }}" --json id -q '.id' 2>/dev/null || echo "")
           if [ -z "$PR_EXISTS" ]; then
             echo "Creating PR for branch ${{ github.ref_name }} against main..."
+            PR_TITLE="Auto PR: ${{ github.ref_name }} - $(date +'%Y-%m-%d')"
             gh pr create \
-              --title "Auto PR: ${{ github.ref_name }}" \
+              --title "$PR_TITLE" \
               --body "Automatically created PR for branch ${{ github.ref_name }}" \
               --base main \
               --head "${{ github.ref_name }}" \
@@ -53,6 +54,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
This commit addresses a failure in the `validate` job of the GitHub Actions workflow.

The root cause of the error was that the `validate_index.py` script, which performs repository validation, requires the full Git history to compare the current branch with `main`. The `validate` job's checkout step was missing `fetch-depth: 0`, which resulted in a shallow clone without the necessary history.

This commit resolves the issue by:
1.  Adding `fetch-depth: 0` to the `actions/checkout@v4` step in the `validate` job of the `.github/workflows/auto-pr-validate.yml` file. This ensures that the script has access to the full Git history.
2.  Updating the `create-pr` job to create more unique pull request titles by appending the current date.

This change should prevent the `##[error]Process` error and allow the validation workflow to run correctly.